### PR TITLE
Calculation Update

### DIFF
--- a/net.clanwolf.starmap.server/src/main/java/net/clanwolf/starmap/server/process/CalcBalance.java
+++ b/net.clanwolf.starmap.server/src/main/java/net/clanwolf/starmap/server/process/CalcBalance.java
@@ -51,7 +51,6 @@ public class CalcBalance {
     private double defenderRepairCost;
     private final Map<RolePlayCharacterStatsPOJO, Double> defenderPlayerRepairCost = new HashMap<>();
     private final Map<RolePlayCharacterStatsPOJO, Double> attackerPlayerRepairCost = new HashMap<>();
-    private final AttackStatsPOJO aSPOJO;
 
 /**
  * Erstellt einen Reparaturbericht, die als Nachricht versendet werden kann.
@@ -116,26 +115,29 @@ public class CalcBalance {
     public Map<RolePlayCharacterStatsPOJO, Double> getAttackerPlayerRepairCost() {
         return attackerPlayerRepairCost;
     }
+    public FactionPOJO getPlayerFaction(Long factionID){
+
+        return FactionDAO.getInstance().findById(Nexus.DUMMY_USERID, factionID);
+    }
 
     /**
      * Berechnet die Reparaturkosten der jeweiligen Seite,
      * die bei {@link #getAttackerPlayerRepairCost()}, {@link #getDefenderPlayerRepairCost()},
      * {@link #getAttackerRepairCost()} und {@link #getDefenderRepairCost()} abgefragt
      * werden können.
-     * @param rpcs AttackStatsPOJO
+     * @param AttackStats AttackStatsPOJO
      */
-    public   CalcBalance(AttackStatsPOJO rpcs){
+    public   CalcBalance(AttackStatsPOJO AttackStats){
 
-        String mwomatchid = rpcs.getMwoMatchId();
+        String mwoMatchID = AttackStats.getMwoMatchId();
         RolePlayCharacterStatsDAO dao = RolePlayCharacterStatsDAO.getInstance();
         RolePlayCharacterDAO characterDAO = RolePlayCharacterDAO.getInstance();
-        ArrayList<RolePlayCharacterStatsPOJO> list = dao.findByMatchId(mwomatchid);
+        ArrayList<RolePlayCharacterStatsPOJO> list = dao.findByMatchId(mwoMatchID);
 
-        FactionPOJO factionAttacker = FactionDAO.getInstance().findById(Nexus.DUMMY_USERID, rpcs.getAttackerFactionId());
-        FactionPOJO factionDefender = FactionDAO.getInstance().findById(Nexus.DUMMY_USERID, rpcs.getDefenderFactionId());
-        FactionPOJO factionWinner = FactionDAO.getInstance().findById(Nexus.DUMMY_USERID, rpcs.getWinnerFactionId());
+        FactionPOJO factionAttacker = FactionDAO.getInstance().findById(Nexus.DUMMY_USERID, AttackStats.getAttackerFactionId());
+        FactionPOJO factionDefender = FactionDAO.getInstance().findById(Nexus.DUMMY_USERID, AttackStats.getDefenderFactionId());
+        FactionPOJO factionWinner = FactionDAO.getInstance().findById(Nexus.DUMMY_USERID, AttackStats.getWinnerFactionId());
 
-        aSPOJO = rpcs;
 
         Long attackerTeam = 0L;
         Long defenderTeam =0L;
@@ -151,21 +153,21 @@ public class CalcBalance {
         mailMessage.append(factionDefender.getName_en());
         mailMessage.append(".\r\n\r\n");
 
-        mailMessage.append(String.format(columnWidthDefault, "Round Id: ")).append(rpcs.getRoundId()).append("\r\n");
-        mailMessage.append(String.format(columnWidthDefault, "Season Id: ")).append(rpcs.getSeasonId()).append("\r\n");
-        mailMessage.append(String.format(columnWidthDefault, "Attack Id: ")).append(rpcs.getAttackId()).append("\r\n");
-        mailMessage.append(String.format(columnWidthDefault, "Id: ")).append(rpcs.getId()).append("\r\n");
-        mailMessage.append(String.format(columnWidthDefault, "Drop Id: ")).append(rpcs.getDropId()).append("\r\n");
-        mailMessage.append(String.format(columnWidthDefault, "MWO Match Id: ")).append(rpcs.getMwoMatchId()).append("\r\n");
-        mailMessage.append(String.format(columnWidthDefault, "Map: ")).append(rpcs.getMap()).append("\r\n");
-        mailMessage.append(String.format(columnWidthDefault, "Game mode: ")).append(rpcs.getMode()).append("\r\n");
+        mailMessage.append(String.format(columnWidthDefault, "Round Id: ")).append(AttackStats.getRoundId()).append("\r\n");
+        mailMessage.append(String.format(columnWidthDefault, "Season Id: ")).append(AttackStats.getSeasonId()).append("\r\n");
+        mailMessage.append(String.format(columnWidthDefault, "Attack Id: ")).append(AttackStats.getAttackId()).append("\r\n");
+        mailMessage.append(String.format(columnWidthDefault, "Id: ")).append(AttackStats.getId()).append("\r\n");
+        mailMessage.append(String.format(columnWidthDefault, "Drop Id: ")).append(AttackStats.getDropId()).append("\r\n");
+        mailMessage.append(String.format(columnWidthDefault, "MWO Match Id: ")).append(AttackStats.getMwoMatchId()).append("\r\n");
+        mailMessage.append(String.format(columnWidthDefault, "Map: ")).append(AttackStats.getMap()).append("\r\n");
+        mailMessage.append(String.format(columnWidthDefault, "Game mode: ")).append(AttackStats.getMode()).append("\r\n");
         mailMessage.append(String.format(columnWidthDefault, "Winner: ")).append(factionWinner.getName_en()).append("\r\n");
 
         try {
 
             String isoDatePattern = "yyyy-MM-dd'T'HH:mm:ssXXX";
             DateFormat dateFormat = new SimpleDateFormat(isoDatePattern);
-            Date parsedDate = dateFormat.parse(rpcs.getDropEnded());
+            Date parsedDate = dateFormat.parse(AttackStats.getDropEnded());
 
             mailMessage.append(String.format(columnWidthDefault, "Drop ended: ")).append(parsedDate).append("\r\n\r\n");
 
@@ -184,23 +186,23 @@ public class CalcBalance {
 
         mailMessage.append("─".repeat(60)).append("\r\n");
         mailMessage.append(String.format(columnWidthDefault,"Tonnage:"));
-        mailMessage.append(String.format(columnWidthDefault,rpcs.getAttackerTonnage()));
-        mailMessage.append(String.format(columnWidthDefault,rpcs.getDefenderTonnage())).append("\r\n");
+        mailMessage.append(String.format(columnWidthDefault,AttackStats.getAttackerTonnage()));
+        mailMessage.append(String.format(columnWidthDefault,AttackStats.getDefenderTonnage())).append("\r\n");
 
         mailMessage.append("─".repeat(60)).append("\r\n");
         mailMessage.append(String.format(columnWidthDefault,"Lost Tonnage:"));
-        mailMessage.append(String.format(columnWidthDefault,rpcs.getAttackerLostTonnage()));
-        mailMessage.append(String.format(columnWidthDefault,rpcs.getDefenderLostTonnage())).append("\r\n");
+        mailMessage.append(String.format(columnWidthDefault,AttackStats.getAttackerLostTonnage()));
+        mailMessage.append(String.format(columnWidthDefault,AttackStats.getDefenderLostTonnage())).append("\r\n");
 
         mailMessage.append("─".repeat(60)).append("\r\n");
         mailMessage.append(String.format(columnWidthDefault,"Kills:"));
-        mailMessage.append(String.format(columnWidthDefault,rpcs.getAttackerKillCount()));
-        mailMessage.append(String.format(columnWidthDefault,rpcs.getDefenderKillCount())).append("\r\n");
+        mailMessage.append(String.format(columnWidthDefault,AttackStats.getAttackerKillCount()));
+        mailMessage.append(String.format(columnWidthDefault,AttackStats.getDefenderKillCount())).append("\r\n");
 
         mailMessage.append("─".repeat(60)).append("\r\n");
         mailMessage.append(String.format(columnWidthDefault,"Number of pilots:"));
-        mailMessage.append(String.format(columnWidthDefault,rpcs.getAttackerNumberOfPilots()));
-        mailMessage.append(String.format(columnWidthDefault,rpcs.getDefenderNumberOfPilots())).append("\r\n");
+        mailMessage.append(String.format(columnWidthDefault,AttackStats.getAttackerNumberOfPilots()));
+        mailMessage.append(String.format(columnWidthDefault,AttackStats.getDefenderNumberOfPilots())).append("\r\n");
 
 
         String attackerDropleadName = "";
@@ -210,20 +212,21 @@ public class CalcBalance {
 
             RolePlayCharacterPOJO character = characterDAO.findById(Nexus.DUMMY_USERID, pojo.getRoleplayCharacterId());
 
-            //Get Attacker Droplead
+            //Get Droplead
             if(pojo.getLeadingPosition()){
-                if(rpcs.getDefenderFactionId().equals(character.getFactionId().longValue())){
+
+                if(AttackStats.getDefenderFactionId().equals(character.getFactionId().longValue())){
                     defenderTeam = pojo.getMwoTeam();
                     defenderDropleadName = character.getMwoUsername();
                 }
-                if(rpcs.getAttackerFactionId().equals(character.getFactionId().longValue())){
+                if(AttackStats.getAttackerFactionId().equals(character.getFactionId().longValue())){
                     attackerTeam = pojo.getMwoTeam();
                     attackerDropleadName = character.getMwoUsername();
                 }
             }
         }
 
-        //Wenn noch kein Attacker Droplead gefunden wurde.
+        //Suche Attacker Droplead, wenn er noch nicht gefunden wurde.
         if(attackerTeam == 0L && defenderTeam > 0){
             for(RolePlayCharacterStatsPOJO pojo : list){
 
@@ -238,7 +241,7 @@ public class CalcBalance {
             }
         }
 
-        //Wenn noch kein Defender Droplead gefunden wurde.
+        //Suche Defender Droplead, wenn er noch nicht gefunden wurde.
         if(defenderTeam == 0L && attackerTeam > 0){
             for(RolePlayCharacterStatsPOJO pojo : list){
 
@@ -277,51 +280,50 @@ public class CalcBalance {
             }
 
             String columnWidthMWOUsername = "%-30.30s";
-            String columnWidthMechname = "%-30.30s";
+            String columnWidthMechName = "%-30.30s";
             String columnWidthPercentToRepair = "%-15.15s";
             String columnWidthRepairCost = "%20.20s";
             String columnWidthTotal = "%-75.75s";
 
-            mailMessage.append("Repair cost for defender " + factionDefender.getName_en() +":\r\n\r\n");
+            mailMessage.append("Repair cost for defender ").append(factionDefender.getName_en()).append(":\r\n\r\n");
             mailMessage.append("─".repeat(95));
             mailMessage.append("\r\n");
-            mailMessage.append(String.format(columnWidthMWOUsername,"MWO Username"));
-            mailMessage.append(String.format(columnWidthMechname,"Mechname"));
-            mailMessage.append(String.format(columnWidthPercentToRepair,"% to repair"));
-            mailMessage.append(String.format(columnWidthRepairCost,"Repaircost"));
+            mailMessage.append(String.format(columnWidthMWOUsername,"Username"));
+            mailMessage.append(String.format(columnWidthMechName,"Description"));
+            mailMessage.append(String.format(columnWidthPercentToRepair," "));
+            mailMessage.append(String.format(columnWidthRepairCost,"Income expenses"));
             mailMessage.append("\r\n");
             mailMessage.append("─".repeat(95));
             mailMessage.append("\r\n");
 
-            for(Map.Entry<RolePlayCharacterStatsPOJO, Double> defuser : getDefenderPlayerRepairCost().entrySet()){
+            for(Map.Entry<RolePlayCharacterStatsPOJO, Double> defUser : getDefenderPlayerRepairCost().entrySet()){
 
-                RolePlayCharacterPOJO character = characterDAO.findById(Nexus.DUMMY_USERID, defuser.getKey().getRoleplayCharacterId());
+                RolePlayCharacterPOJO character = characterDAO.findById(Nexus.DUMMY_USERID, defUser.getKey().getRoleplayCharacterId());
 
                 mailMessage.append(String.format(columnWidthMWOUsername,character.getMwoUsername()));
 
-                MechIdInfo MI = new MechIdInfo(Math.toIntExact(defuser.getKey().getMechItemId()));
+                MechIdInfo MI = new MechIdInfo(Math.toIntExact(defUser.getKey().getMechItemId()));
 
-                mailMessage.append(String.format(columnWidthMechname,MI.getFullname()));
-                mailMessage.append(String.format(columnWidthPercentToRepair,(100L - defuser.getKey().getMwoSurvivalPercentage() + "%")));
-                mailMessage.append(String.format(columnWidthRepairCost,nf.format(defuser.getValue().longValue()) + " C-Bills"));
+                mailMessage.append(String.format(columnWidthMechName,MI.getFullname()));
+                mailMessage.append(String.format(columnWidthPercentToRepair,"Repair(" + (100L - defUser.getKey().getMwoSurvivalPercentage() + "%)") ));
+                mailMessage.append(String.format(columnWidthRepairCost,nf.format(defUser.getValue().longValue()) + " C-Bills"));
                 mailMessage.append("\r\n");
 
+                mailMessage.append(String.format(columnWidthMWOUsername, character.getMwoUsername()));
+                mailMessage.append(String.format(columnWidthMechName,"Income from " + getPlayerFaction((long) character.getFactionId()).getShortName()));
+                mailMessage.append(String.format(columnWidthPercentToRepair," "));
+                mailMessage.append(String.format(columnWidthRepairCost,nf.format(getIncome(character.getFactionId())) + " C-Bills"));
+                mailMessage.append("\r\n");
+                setDefenderRepairCost(getIncome(character.getFactionId()));
+
+                mailMessage.append(String.format(columnWidthMWOUsername, character.getMwoUsername()));
+                mailMessage.append(String.format(columnWidthMechName,"Defend cost"));
+                mailMessage.append(String.format(columnWidthPercentToRepair," "));
+                mailMessage.append(String.format(columnWidthRepairCost,nf.format(getDefendCost(AttackStats.getStarSystemDataId())) + " C-Bills"));
+                mailMessage.append("\r\n");
+                setDefenderRepairCost(getDefendCost(AttackStats.getStarSystemDataId()));
+
             }
-            mailMessage.append("─".repeat(95));
-            mailMessage.append("\r\n");
-            mailMessage.append(String.format(columnWidthTotal,"Defend cost:"));
-            mailMessage.append(String.format(columnWidthRepairCost,nf.format(getDefendCost(rpcs.getStarSystemDataId())) + " C-Bills"));
-            mailMessage.append("\r\n");
-
-            setDefenderRepairCost(getDefendCost(rpcs.getStarSystemDataId()) );
-
-            mailMessage.append("─".repeat(95));
-            mailMessage.append("\r\n");
-            mailMessage.append(String.format(columnWidthTotal,"Income:"));
-            mailMessage.append(String.format(columnWidthRepairCost,nf.format(getIncome(factionDefender.getId())) + " C-Bills"));
-            mailMessage.append("\r\n");
-
-            setDefenderRepairCost(getIncome(factionDefender.getId()));
 
             mailMessage.append("─".repeat(95));
             mailMessage.append("\r\n");
@@ -331,46 +333,43 @@ public class CalcBalance {
             mailMessage.append("═".repeat(95));
             mailMessage.append("\r\n\r\n");
 
-            mailMessage.append("Repair cost for attacker " + factionAttacker.getName_en() +":\r\n\r\n");
+            mailMessage.append("Repair cost for attacker ").append(factionAttacker.getName_en()).append(":\r\n\r\n");
             mailMessage.append("─".repeat(95));
             mailMessage.append("\r\n");
-            mailMessage.append(String.format(columnWidthMWOUsername,"MWO Username"));
-            mailMessage.append(String.format(columnWidthMechname,"Mechname"));
-            mailMessage.append(String.format(columnWidthPercentToRepair,"% to repair"));
-            mailMessage.append(String.format(columnWidthRepairCost,"Repaircost"));
+            mailMessage.append(String.format(columnWidthMWOUsername,"Username"));
+            mailMessage.append(String.format(columnWidthMechName,"Description"));
+            mailMessage.append(String.format(columnWidthPercentToRepair," "));
+            mailMessage.append(String.format(columnWidthRepairCost,"Income expenses"));
             mailMessage.append("\r\n");
             mailMessage.append("─".repeat(95));
             mailMessage.append("\r\n");
 
-            for(Map.Entry<RolePlayCharacterStatsPOJO, Double> attuser : getAttackerPlayerRepairCost().entrySet()){
+            for(Map.Entry<RolePlayCharacterStatsPOJO, Double> attUser : getAttackerPlayerRepairCost().entrySet()){
 
-                RolePlayCharacterPOJO character = characterDAO.findById(Nexus.DUMMY_USERID, attuser.getKey().getRoleplayCharacterId());
+                RolePlayCharacterPOJO character = characterDAO.findById(Nexus.DUMMY_USERID, attUser.getKey().getRoleplayCharacterId());
 
                 mailMessage.append(String.format(columnWidthMWOUsername,character.getMwoUsername()));
-                MechIdInfo MI = new MechIdInfo(Math.toIntExact(attuser.getKey().getMechItemId()));
-                mailMessage.append(String.format(columnWidthMechname,MI.getFullname()));
-                mailMessage.append(String.format(columnWidthPercentToRepair,(100L - attuser.getKey().getMwoSurvivalPercentage()) + "%"));
-                mailMessage.append(String.format(columnWidthRepairCost,nf.format(attuser.getValue().longValue()) + " C-Bills"));
+                MechIdInfo MI = new MechIdInfo(Math.toIntExact(attUser.getKey().getMechItemId()));
+                mailMessage.append(String.format(columnWidthMechName,MI.getFullname()));
+                mailMessage.append(String.format(columnWidthPercentToRepair,"Repair(" + (100L - attUser.getKey().getMwoSurvivalPercentage()) + "%)"));
+                mailMessage.append(String.format(columnWidthRepairCost,nf.format(attUser.getValue().longValue()) + " C-Bills"));
                 mailMessage.append("\r\n");
 
+                mailMessage.append(String.format(columnWidthMWOUsername, character.getMwoUsername()));
+                mailMessage.append(String.format(columnWidthMechName,"Income from " + getPlayerFaction((long) character.getFactionId()).getShortName()));
+                mailMessage.append(String.format(columnWidthPercentToRepair," "));
+                mailMessage.append(String.format(columnWidthRepairCost,nf.format(getIncome(character.getFactionId())) + " C-Bills"));
+                mailMessage.append("\r\n");
+                setAttackerRepairCost(getIncome(character.getFactionId()));
+
+                mailMessage.append(String.format(columnWidthMWOUsername, character.getMwoUsername()));
+                mailMessage.append(String.format(columnWidthMechName,"Attack cost"));
+                mailMessage.append(String.format(columnWidthPercentToRepair," "));
+                mailMessage.append(String.format(columnWidthRepairCost,nf.format(getAttackCost(AttackStats.getStarSystemDataId())) + " C-Bills"));
+                mailMessage.append("\r\n");
+                setAttackerRepairCost(getAttackCost(AttackStats.getStarSystemDataId()));
+
             }
-
-            mailMessage.append("─".repeat(95));
-            mailMessage.append("\r\n");
-            mailMessage.append(String.format(columnWidthTotal,"Attack cost:"));
-            mailMessage.append(String.format(columnWidthRepairCost,nf.format(getAttackCost(rpcs.getStarSystemDataId())) + " C-Bills"));
-            mailMessage.append("\r\n");
-
-            setAttackerRepairCost(getAttackCost(rpcs.getStarSystemDataId()) );
-
-
-            mailMessage.append("─".repeat(95));
-            mailMessage.append("\r\n");
-            mailMessage.append(String.format(columnWidthTotal,"Income:"));
-            mailMessage.append(String.format(columnWidthRepairCost,nf.format(getIncome(factionAttacker.getId())) + " C-Bills"));
-            mailMessage.append("\r\n");
-
-            setAttackerRepairCost(getIncome(factionAttacker.getId()));
 
             mailMessage.append("─".repeat(95));
             mailMessage.append("\r\n");
@@ -392,16 +391,16 @@ public class CalcBalance {
      */
     public long getDefendCost(long starSystemDataId){
         long cost = 0L;
-        ArrayList<StarSystemDataPOJO> starsystemdataListHH = StarSystemDataDAO.getInstance().getAll_HH_StarSystemData();
+        ArrayList<StarSystemDataPOJO> starSystemDataListHH = StarSystemDataDAO.getInstance().getAll_HH_StarSystemData();
 
-        for (StarSystemDataPOJO starsystemdata : starsystemdataListHH) {
-            if(starsystemdata.getStarSystemID().getId().equals(starSystemDataId)){
-                switch (starsystemdata.getLevel().intValue()) {
+        for (StarSystemDataPOJO starSystemData : starSystemDataListHH) {
+            if(starSystemData.getStarSystemID().getId().equals(starSystemDataId)){
+                switch (starSystemData.getLevel().intValue()) {
                     case 1 -> // Regular world
                             cost = cost + Constants.REGULAR_SYSTEM_DEFEND_COST;
                     case 2 -> // Industrial world
                             cost = cost + Constants.INDUSTRIAL_SYSTEM_DEFEND_COST;
-                    case 3 -> // Captial world
+                    case 3 -> // Capital world
                             cost = cost + Constants.CAPITAL_SYSTEM_DEFEND_COST;
                 }
                 break;
@@ -418,16 +417,16 @@ public class CalcBalance {
     public long getAttackCost(long starSystemDataId){
 
         long cost = 0L;
-        ArrayList<StarSystemDataPOJO> starsystemdataListHH = StarSystemDataDAO.getInstance().getAll_HH_StarSystemData();
+        ArrayList<StarSystemDataPOJO> starSystemDataListHH = StarSystemDataDAO.getInstance().getAll_HH_StarSystemData();
 
-        for (StarSystemDataPOJO starsystemdata : starsystemdataListHH) {
-            if(starsystemdata.getStarSystemID().getId().equals(starSystemDataId)){
-                switch (starsystemdata.getLevel().intValue()) {
+        for (StarSystemDataPOJO starSystemData : starSystemDataListHH) {
+            if(starSystemData.getStarSystemID().getId().equals(starSystemDataId)){
+                switch (starSystemData.getLevel().intValue()) {
                     case 1 -> // Regular world
                             cost = cost + Constants.REGULAR_SYSTEM_ATTACK_COST;
                     case 2 -> // Industrial world
                             cost = cost + Constants.INDUSTRIAL_SYSTEM_ATTACK_COST;
-                    case 3 -> // Captial world
+                    case 3 -> // Capital world
                             cost = cost + Constants.CAPITAL_SYSTEM_ATTACK_COST;
                 }
                 break;
@@ -446,11 +445,11 @@ public class CalcBalance {
         long income = 0L;
         long cost = 0L;
 
-        ArrayList<StarSystemDataPOJO> starsystemdataListHH = StarSystemDataDAO.getInstance().getAll_HH_StarSystemData();
-        for (StarSystemDataPOJO starsystemdata : starsystemdataListHH) {
-            if (starsystemdata.getFactionID().getId().equals(userFactionId)) {
+        ArrayList<StarSystemDataPOJO> starSystemDataListHH = StarSystemDataDAO.getInstance().getAll_HH_StarSystemData();
+        for (StarSystemDataPOJO starSystemData : starSystemDataListHH) {
+            if (starSystemData.getFactionID().getId().equals(userFactionId)) {
 
-                switch (starsystemdata.getLevel().intValue()) {
+                switch (starSystemData.getLevel().intValue()) {
                     case 1 -> { // Regular
 
                         income = income + Constants.REGULAR_SYSTEM_GENERAL_INCOME;

--- a/net.clanwolf.starmap.server/src/main/java/net/clanwolf/starmap/server/process/EndRound.java
+++ b/net.clanwolf.starmap.server/src/main/java/net/clanwolf/starmap/server/process/EndRound.java
@@ -239,7 +239,8 @@ public class EndRound {
 						FactionPOJO factionAttacker = FactionDAO.getInstance().findById(Nexus.DUMMY_USERID, asp.getAttackerFactionId());
 						FactionPOJO factionDefender = FactionDAO.getInstance().findById(Nexus.DUMMY_USERID, asp.getDefenderFactionId());
 
-						logger.info("---Calculate the repair costs of the attacker " + factionAttacker.getName_en() + " and the defender " + factionDefender.getName_en() + ".");
+
+						logger.info("--- Calculate the balace costs [" + factionAttacker.getShortName() + "] versus [" + factionDefender.getShortName() + "] (MatchID: " + asp.getMwoMatchId() + " )---");
 
 						CalcBalance calcB = new CalcBalance(asp);
 

--- a/net.clanwolf.starmap.server/src/main/java/net/clanwolf/starmap/server/process/EndRound.java
+++ b/net.clanwolf.starmap.server/src/main/java/net/clanwolf/starmap/server/process/EndRound.java
@@ -429,7 +429,7 @@ public class EndRound {
 					s += "Defending: " + countDefending + "\r\n";
 					s += "Income: " + income + " k₵\r\n";
 					s += "Cost: " + cost + " k₵\r\n";
-					s += "Balance: " + (income - cost) + " k₵\r\n";
+					s += "Balance: " + (income + cost) + " k₵\r\n";
 					factionStatistics.add(s);
 
 					systemCostMap.put(faction.getId(), cost);

--- a/net.clanwolf.starmap.transfer/src/main/java/net/clanwolf/starmap/constants/Constants.java
+++ b/net.clanwolf.starmap.transfer/src/main/java/net/clanwolf/starmap/constants/Constants.java
@@ -39,23 +39,23 @@ public class Constants implements java.io.Serializable {
 	public static final long FACTION_CAPITAL_SYSTEM_GENERAL_INCOME = 25_000;
 	public static final long TERRA_GENERAL_INCOME = 55_000;
 
-	public static final long REGULAR_SYSTEM_GENERAL_COST = 150;
-	public static final long INDUSTRIAL_SYSTEM_GENERAL_COST = 1_000;
-	public static final long CAPITAL_SYSTEM_GENERAL_COST = 2_000;
-	public static final long FACTION_CAPITAL_SYSTEM_GENERAL_COST = 17_000;
-	public static final long TERRA_GENERAL_COST = 22_000;
+	public static final long REGULAR_SYSTEM_GENERAL_COST = -150;
+	public static final long INDUSTRIAL_SYSTEM_GENERAL_COST = -1_000;
+	public static final long CAPITAL_SYSTEM_GENERAL_COST = -2_000;
+	public static final long FACTION_CAPITAL_SYSTEM_GENERAL_COST = -17_000;
+	public static final long TERRA_GENERAL_COST = -22_000;
 
-	public static final long REGULAR_SYSTEM_DEFEND_COST = 120;
-	public static final long INDUSTRIAL_SYSTEM_DEFEND_COST = 300;
-	public static final long CAPITAL_SYSTEM_DEFEND_COST = 500;
-	public static final long FACTION_CAPITAL_SYSTEM_DEFEND_COST = 1500;
-	public static final long TERRA_DEFEND_COST = 11500;
+	public static final long REGULAR_SYSTEM_DEFEND_COST = -120;
+	public static final long INDUSTRIAL_SYSTEM_DEFEND_COST = -300;
+	public static final long CAPITAL_SYSTEM_DEFEND_COST = -500;
+	public static final long FACTION_CAPITAL_SYSTEM_DEFEND_COST = -1500;
+	public static final long TERRA_DEFEND_COST = -11500;
 
-	public static final long REGULAR_SYSTEM_ATTACK_COST = 3_000;
-	public static final long INDUSTRIAL_SYSTEM_ATTACK_COST = 6_000;
-	public static final long CAPITAL_SYSTEM_ATTACK_COST = 10_000;
-	public static final long FACTION_CAPITAL_SYSTEM_ATTACK_COST = 20_000;
-	public static final long TERRA_ATTACK_COST = 100_000;
+	public static final long REGULAR_SYSTEM_ATTACK_COST = -3_000;
+	public static final long INDUSTRIAL_SYSTEM_ATTACK_COST = -6_000;
+	public static final long CAPITAL_SYSTEM_ATTACK_COST = -10_000;
+	public static final long FACTION_CAPITAL_SYSTEM_ATTACK_COST = -20_000;
+	public static final long TERRA_ATTACK_COST = -100_000;
 
 	// Game - Meta
 	public static final long ROUNDS_TO_LOCK_SYSTEM_AFTER_ATTACK = 3;

--- a/net.clanwolf.starmap.transfer/src/main/java/net/clanwolf/starmap/transfer/mwo/MechIdInfo.java
+++ b/net.clanwolf.starmap.transfer/src/main/java/net/clanwolf/starmap/transfer/mwo/MechIdInfo.java
@@ -1151,7 +1151,7 @@ public class MechIdInfo {
 
         };
 
-        return getTonnage() * 200000 * Multiply;
+        return getTonnage() * -100000 * Multiply;
     }
 
     public double getRepairCost(Integer HealthPercentage){


### PR DESCRIPTION
- UDATED: Constant for expenses have been provided with a minus sign, in order to only need to add when calculating costs.
- UPDATED: The cost multiplier for the repairs of the mech, was set down.
- ADDED: Methods have been added in CalcBalance to calculate revenues and expenses.
- ADDED: The cost report is now displayed with thousands separator.
- FIXED: Fixed a bug that a droplead could not be found during calculation. This is probably because the faction to which it belongs was changed in between.
- ADDED: The cost report now shows income, defense and attack costs.